### PR TITLE
chore: add vitest test scripts to app packages

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev -p 3001 --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/apps/clients/package.json
+++ b/apps/clients/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev -p 3002 --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/apps/courses/package.json
+++ b/apps/courses/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev -p 3003 --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev -p 3000 --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "react": "19.1.0",


### PR DESCRIPTION
## Summary
- add `test` and `test:run` scripts using Vitest to each app's package.json

## Testing
- `npm test -w apps/admin` *(fails: vitest not found)*
- `npm test -w apps/clients` *(fails: vitest not found)*
- `npm test -w apps/courses` *(fails: vitest not found)*
- `npm test -w apps/web` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c031230880832298fc63c9e67a59a5